### PR TITLE
Fix array being printed into Packages

### DIFF
--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -70,7 +70,7 @@ module Debian
 
         FileUtils.rmtree 'tmp/'
 
-        d.write control_data
+        d.write control_data.join("\n")
         d.close
 
         data = ''


### PR DESCRIPTION
Fix for array string being printed into Packages - rather than write the array object we write the array joined with newlines.
