### PR TITLE
Remove parallel each as it creates a race condition

### DIFF
--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'fileutils'
 require 'zlib'
 require 'digest/md5'
-require 'peach' 
 require 'erb'
 require 'find'
 require 'aws/s3'
@@ -39,7 +38,7 @@ module Debian
         npath = "dists/" + r + "/" + c + "/" + "binary-" + a + "/"
         packages_text = []
 
-        Dir.glob("#{fpath}*.deb").peach do |deb|
+        Dir.glob("#{fpath}*.deb").each do |deb|
             md5sum = ''
             tdeb = deb.split('/').last
             md5sum_path = path + "/dists/" + r + "/" + c + "/" + "binary-" + a + "/md5-results/" + tdeb


### PR DESCRIPTION
The parallel each usage breaks the Packages file - it creates a race condition where two threads are writing to the same file at the same time, resulting in a broken Packages file.

This commit removes the 'peach' iteration, as this causes the problem.
