### PR TITLE
Glob files to include in gem more effectively.

### DIFF
--- a/prm.gemspec
+++ b/prm.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = %Q(PRM (Package Repository Manager) is an Operating System independent Package Repository tool. It allows you to quickly build Debian and Yum Package Repositories. PRM supports Repository syncing to DreamObjects )
   s.authors     = ["Brett Gailey"]
   s.email       = 'brett.gailey@dreamhost.com'
-  s.files       = [ "lib/prm/repo.rb", "lib/prm.rb", "templates/deb_release.erb", "lib/prm/rpm.rb" ]
+  s.files       = Dir.glob("{lib,templates}/**/*")
   s.bindir	  = 'bin'
   s.executables = ['prm']
   s.add_dependency('peach')


### PR DESCRIPTION
I was receiving a ENOENT when trying to create an RPM repository
due to a missing template (primary.xml.erb to be specific). I
looked in the gem lib and the templates dir only had the 
deb_release.erb installed. Using Dir.glob grabs all the necessary
files.

I left the version number alone so that you can bump it to whatever you please.
