### PR TITLE
Bug fix: Remove unused sqlite3 dependency

### DIFF
--- a/prm.gemspec
+++ b/prm.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'prm'
-  s.version     = '0.2.2'
+  s.version     = '0.2.3'
   s.date        = '2013-08-18'
   s.summary     = "Package Repository Manager"
   s.description = %Q(PRM (Package Repository Manager) is an Operating System independent Package Repository tool. It allows you to quickly build Debian and Yum Package Repositories. PRM supports Repository syncing to DreamObjects )
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_dependency('aws-s3')
   s.add_dependency('clamp')
   s.add_dependency('arr-pm')
-  s.add_dependency('sqlite3')
   s.homepage    = 'https://github.com/dnbert/prm'
   s.license = 'MIT'
 end


### PR DESCRIPTION
I'm pretty sure this isn't used anywhere in the code base, and it means my apt servers need the sqlite3 development packages to install the sqlite3 gem or prm install fails.

I did a little grepping for sqlite and had a look if any gems depended on it in the Gemfile.lock but found nothing.

I've bumped the patch version.

If it is used and I've misdiagnosed this, feel free to close and delete :)
