### PR TITLE
Chomp the .deb control file before writing out Packages.gz.

### DIFF
--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -112,7 +112,7 @@ module Debian
 
             write_mutex.synchronize do
                 # Copy the control file data into the Packages list
-                d.write(File.read("tmp/#{tdeb}/control"))
+                d.write(File.read("tmp/#{tdeb}/control").chomp)
                 d.write(package_info.join("\n"))
                 d.write("\n") # blank line between package info in the Packages file
             end


### PR DESCRIPTION
Some debs (RStudio _cough_) have an extra newline at the end of their control file.  This makes for a Packages.gz file with syntax errors, which in turn breaks apt-get update.  Not sure if it's a bug on the packager's part, but this patch does get around that problem.
