### PR TITLE
Fix for + signs in filenames within S3-hosted apt repositories

### DIFF
--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -123,7 +123,7 @@ module Debian
             end
 
             package_info = [
-                "Filename: #{npath}#{tdeb}",
+                "Filename: #{npath}#{s3_compatible_encode(tdeb)}",
                 "MD5sum: #{md5sum}",
                 "Size: #{init_size}"
             ]
@@ -202,6 +202,10 @@ module Debian
             end
             system sign_cmd
         end
+    end
+
+    def s3_compatible_encode(str)
+        str.gsub(/[#\$&'\(\)\*\+,\/:;=\?@\[\]]/) { |x| x.each_byte.map { |b| '%' + b.to_s(16) }.join }
     end
 end
 


### PR DESCRIPTION
Amazon S3 has a bug wherein it treats the `+` character in the path component of all URLs as a space, rather than a distinct path character. As a result, all `+` characters must be encoded to `%2B` in order to be accessible on S3.

Per Amazon's official proposed solution, this patch forcibly URL-encodes all RFC 3986 characters that are part of the filename so generated repositories function correctly on S3 even when package filenames contain the + character.