### PR TITLE
Add support for Label and Origin metadata in Debian release files

### DIFF
--- a/bin/prm
+++ b/bin/prm
@@ -16,6 +16,8 @@ class Main < Clamp::Command
   option ["-r", "--release"], "RELEASE", "OS version to create", :required => true
   option ["-a", "--arch"], "ARCH", "Architecture of repo contents", :required => true
   option ["-c", "--component"], "COMPONENT", "Component to create [DEB ONLY]"
+  option ["-l", "--label"], "LABEL", "Label for generated repository [DEB ONLY]"
+  option ["-o", "--origin"], "ORIGIN", "Origin for generated repository [DEB ONLY]"
   option ["--nocache"], :flag, "Don't cache md5 sums [DEB ONLY]"
   option ["--accesskey"], "ACCESS KEY", "DHO/S3 Access Key", :default => false
   option ["--secretkey"], "SECRET KEY", "DHO/S3 Secret Key", :default => false
@@ -42,6 +44,8 @@ class Main < Clamp::Command
     r.arch = arch
     r.type = type
     r.path = path
+    r.label = label
+    r.origin = origin
     unless gpg.nil?
       r.gpg = gpg
     end

--- a/lib/prm/rpm.rb
+++ b/lib/prm/rpm.rb
@@ -58,9 +58,7 @@ module Redhat
                 template_dir = File.join(File.dirname(__FILE__), "..", "..", "templates")
 
                 erb_files.each { |f|
-                    erb = ERB.new(File.open("#{template_dir}/#{f}.xml.erb") { |file|
-                        file.read
-                    }).result(binding)
+                    erb = ERB.new(File.read("#{template_dir}/#{f}.xml.erb"), nil, "-").result(binding)
 
                     release_file = File.new("#{repo_path}/#{f}.xml","wb")
                     release_file.puts erb
@@ -115,7 +113,7 @@ module Redhat
                 timestamp = Time.now.to_i
 
                 repomd_xml << create_repomd_xml(xml_data_hash,timestamp)
-                erb_two = ERB.new(File.open("#{template_dir}/repomd.xml.erb") { |file|
+                erb_two = ERB.new(File.open("#{template_dir}/repomd.xml.erb", nil, "-") { |file|
                     file.read
                 }).result(binding)
 

--- a/templates/deb_release.erb
+++ b/templates/deb_release.erb
@@ -1,7 +1,13 @@
 Date: <%= date %>
 Suite: <%= release %>
+<% if origin -%>
+Origin: <%= origin %>
+<% end -%>
+<% if label -%>
+Label: <%= label %>
+<% end -%>
 MD5Sum:
  d41d8cd98f00b204e9800998ecf8427e                  0 Release
-<% release_info.each_pair do |k,v| %> <%= 
- "#{release_info[k]['md5sum']}                  #{release_info[k]['size']} #{k}" %>  
-<% end %>
+<% release_info.each_pair do |k,v| -%>
+ <%= "#{release_info[k]['md5sum']}                  #{release_info[k]['size']} #{k}" %>
+<% end -%>


### PR DESCRIPTION
Debian repositories support Label and Origin metadata which can be used for resolving pin preferences in apt. This PR adds support via the `--label` and `--origin` flags for including this metadata in the generated file.