### PR TITLE
adds -d support for yum repos

### DIFF
--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -38,7 +38,7 @@ module Debian
         }
     end
 
-    def move_packages(path,component,arch,release,directory)
+    def move_apt_packages(path,component,arch,release,directory)
         unless File.exists?(directory)
             puts "ERROR: #{directory} doesn't exist... not doing anything\n"
             return false
@@ -54,7 +54,7 @@ module Debian
                             if file =~ /^.*#{r}.*\.deb$/i
                                 # Lets do this here to help mitigate packages like "asdf-123+wheezy.deb"
                                 FileUtils.cp(file, "#{path}/dists/#{r}/#{c}/binary-#{a}/")
-                            FileUtils.rm(file)
+                                FileUtils.rm(file)
                             else
                                 FileUtils.cp(file, "#{path}/dists/#{r}/#{c}/binary-#{a}/")
                                 files_moved << file
@@ -370,7 +370,7 @@ module PRM
                 if directory
                     silent = true
                     build_apt_repo(path,pcomponent,parch,prelease,label,origin,gpg,silent,nocache)
-                    if move_packages(path,pcomponent,parch,prelease,directory) == false
+                    if move_apt_packages(path,pcomponent,parch,prelease,directory) == false
                         return
                     end
                 end
@@ -383,6 +383,13 @@ module PRM
             elsif "#{@type}" == "rpm"
                 component = nil
                 parch,pcomponent,prelease = _parse_vars(arch,component,release)
+                if directory
+                    silent = true
+                    build_rpm_repo(path,parch,prelease,gpg,silent)
+                    if move_rpm_packages(path,parch,prelease,directory) == false
+                        return
+                    end
+                end
                 silent = false
                 build_rpm_repo(path,parch,prelease,gpg,silent)
             end

--- a/lib/prm/rpm.rb
+++ b/lib/prm/rpm.rb
@@ -127,6 +127,40 @@ module Redhat
         end
     end
 
+    def move_rpm_packages(path,arch,release,directory)
+        unless File.exists?(directory)
+            puts "ERROR: #{directory} doesn't exist... not doing anything\n"
+            return false
+        end
+
+        files_moved = Array.new
+        release.each { |r|
+            arch.each { |a|
+                puts a
+                Dir.glob(directory + "/*.rpm") do |file|
+                    if file =~ /^.*#{a}.*\.rpm$/i || file =~ /^.*all.*\.rpm$/i || file =~ /^.*any.*\.rpm$/i
+                        target_dir = "#{path}/#{r}/#{a}/"
+                        FileUtils.mkpath(target_dir)
+                        if file =~ /^.*#{r}.*\.rpm$/i
+                            # Lets do this here to help mitigate packages like "asdf-123+rhel7.rpm"
+                            FileUtils.cp(file, target_dir)
+                            FileUtils.rm(file)
+                        else
+                            FileUtils.cp(file, target_dir)
+                            files_moved << file
+                        end
+                    end
+                end
+            }
+        }
+
+        files_moved.each do |f|
+            if File.exists?(f)
+                FileUtils.rm(f)
+            end
+        end
+    end
+
     def create_repomd_xml(xml_data_hash,timestamp)
         repomd_meta = String.new
         xml_data_hash.each_pair do |k,v|


### PR DESCRIPTION
I believe this satisfies #38.

Largely duplicates the existing apt codepath.  Renames `move_packages` to `move_apt_packages` to be more specific and avoid confusion alongside the new `move_rpm_packages`.

