### PR TITLE
allow for GPG passphrase as an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Options:
 -e, --recent                  Snapshot the most recent unique packages (default: false)
 -g, --generate                [DEPRECATED 0.2.4]
 -k, --gpg GPG KEY             Sign release files with this GPG key (default: false)
+-x, --gpg_passphrase          Provide GPG passphrase to prevent prompt by GPG (default: false)
 -h, --help                    print help
 ```
 
@@ -99,6 +100,8 @@ Example
 prm --type deb --path pool --component dev,staging --release precise --arch amd64 --gpg
 
 prm -t deb -p pool -c stable -r precise -a amd64 --directory unstable
+
+prm -t deb -p pool -c stable -r precise -a amd64 --directory unstable --gpg user@domain.com --gpg_password myPa55word
 
 prm -t rpm -a x86_64 -r centos6 -p pool
 ```

--- a/bin/prm
+++ b/bin/prm
@@ -31,6 +31,7 @@ class Main < Clamp::Command
 	  "This option will be removed in next stable release (0.3.0)\n"
   end
   option ["-k", "--gpg"], "GPG KEY",  "Sign release files with this GPG key", :default => false
+  option ["-x", "--gpg_passphrase"], "GPG PASSPHRASE", "Passphrase for GPG key", :default => false
 
   def execute
 	if version?
@@ -63,6 +64,7 @@ class Main < Clamp::Command
 	end
     unless gpg.nil?
       r.gpg = gpg
+      r.gpg_passphrase = gpg_passphrase
     end
     unless accesskey.nil?
       r.accesskey = accesskey

--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -194,6 +194,8 @@ module Debian
         Dir.chdir("#{path}/dists/#{release}") do
             if gpg.nil?
               sign_cmd = "gpg --yes --output Release.gpg -b Release"
+            elsif !gpg_passphrase.nil?
+              sign_cmd = "echo \'#{gpg_passphrase}\' | gpg -u #{gpg} --passphrase-fd 0 --yes --output Release.gpg -b Release"
             else
               sign_cmd = "gpg -u #{gpg} --yes --output Release.gpg -b Release"
             end
@@ -352,6 +354,7 @@ module PRM
         attr_accessor :label
         attr_accessor :origin
         attr_accessor :gpg
+        attr_accessor :gpg_passphrase
         attr_accessor :secretkey
         attr_accessor :accesskey
         attr_accessor :snapshot


### PR DESCRIPTION
I created an argument called gpg_passphrase to pass in a GPG passphrase so I could generate a signed Debian repo using an automated process.  Let me know if the ruby code is not best practice; I don't write code full-time.  I suggest when using it on the command line, set the password in an environment variable that gets used in the prm command.