### PR TITLE
deb: support SHA1 and SHA256 checksums

### DIFF
--- a/templates/deb_release.erb
+++ b/templates/deb_release.erb
@@ -7,7 +7,17 @@ Origin: <%= origin %>
 Label: <%= label %>
 <% end -%>
 MD5Sum:
- d41d8cd98f00b204e9800998ecf8427e                  0 Release
+ d41d8cd98f00b204e9800998ecf8427e                                 0 Release
 <% release_info.each_pair do |k,v| -%>
- <%= "#{release_info[k]['md5sum']}                  #{release_info[k]['size']} #{k}" %>
+ <%= "#{release_info[k]['md5']}                                 #{release_info[k]['size']} #{k}" %>
+<% end -%>
+SHA1:
+ da39a3ee5e6b4b0d3255bfef95601890afd80709                         0 Release
+<% release_info.each_pair do |k,v| -%>
+ <%= "#{release_info[k]['sha1']}                         #{release_info[k]['size']} #{k}" %>
+<% end -%>
+SHA256:
+ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 0 Release
+<% release_info.each_pair do |k,v| -%>
+ <%= "#{release_info[k]['sha256']} #{release_info[k]['size']} #{k}" %>
 <% end -%>


### PR DESCRIPTION
Adds support for SHA1 and SHA256 checksums to Release and Packages files.

My .vimrc automatically trimmed trailing whitespace from a few unrelated lines. I can manually fix if it's a problem.

Closes #59.