### PR TITLE
debian: Use RFC2822 dates

### DIFF
--- a/templates/deb_release.erb
+++ b/templates/deb_release.erb
@@ -1,4 +1,4 @@
-Date: <%= date %>
+Date: <%= date.rfc2822 %>
 Suite: <%= release %>
 <% if origin -%>
 Origin: <%= origin %>


### PR DESCRIPTION
Use RFC 2822 dates for Debian Release files, as per the Debian Policy Manual:
https://www.debian.org/doc/debian-policy/ch-source.html

Closes #61.
