### PR TITLE
Support command line flag for specifying package signing algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Options:
 -g, --generate                [DEPRECATED 0.2.4]
 -k, --gpg GPG KEY             Sign release files with this GPG key (default: false)
 -x, --gpg_passphrase          Provide GPG passphrase to prevent prompt by GPG (default: false)
+-n, --gpg_sign_algorithm      Provide GPG hash digest signing algorithm (default: false)
 -h, --help                    print help
 ```
 

--- a/bin/prm
+++ b/bin/prm
@@ -32,6 +32,7 @@ class Main < Clamp::Command
   end
   option ["-k", "--gpg"], "GPG KEY",  "Sign release files with this GPG key", :default => false
   option ["-x", "--gpg_passphrase"], "GPG PASSPHRASE", "Passphrase for GPG key", :default => false
+  option ["-n", "--gpg_sign_algorithm"], "GPG SIGN ALGORITHM", "Digest algorithm to use for signing (e.g SHA1, SHA512, etc)", :default => false
 
   def execute
 	if version?
@@ -65,6 +66,7 @@ class Main < Clamp::Command
     unless gpg.nil?
       r.gpg = gpg
       r.gpg_passphrase = gpg_passphrase
+      r.gpg_sign_algorithm = gpg_sign_algorithm
     end
     unless accesskey.nil?
       r.accesskey = accesskey

--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -192,12 +192,18 @@ module Debian
     # We expect that GPG is installed and a key has already been made
     def generate_release_gpg(path,release,gpg)
         Dir.chdir("#{path}/dists/#{release}") do
-            if gpg.nil?
-              sign_cmd = "gpg --yes --output Release.gpg -b Release"
-            elsif !gpg_passphrase.nil?
-              sign_cmd = "echo \'#{gpg_passphrase}\' | gpg -u #{gpg} --passphrase-fd 0 --yes --output Release.gpg -b Release"
+            if gpg_sign_algorithm.nil?
+                sign_algorithm = "none"
             else
-              sign_cmd = "gpg -u #{gpg} --yes --output Release.gpg -b Release"
+                sign_algorithm = gpg_sign_algorithm
+            end
+
+            if gpg.nil?
+              sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" --yes --output Release.gpg -b Release"
+            elsif !gpg_passphrase.nil?
+              sign_cmd = "echo \'#{gpg_passphrase}\' | gpg --digest-algo \"#{sign_algorithm}\" -u #{gpg} --passphrase-fd 0 --yes --output Release.gpg -b Release"
+            else
+              sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" -u #{gpg} --yes --output Release.gpg -b Release"
             end
             system sign_cmd
         end
@@ -355,6 +361,7 @@ module PRM
         attr_accessor :origin
         attr_accessor :gpg
         attr_accessor :gpg_passphrase
+        attr_accessor :gpg_sign_algorithm
         attr_accessor :secretkey
         attr_accessor :accesskey
         attr_accessor :snapshot


### PR DESCRIPTION
Fixes https://github.com/dnbert/prm/issues/65

See issue for additional information.

Can be used like:

```
$ prm --gpg --gpg_sign_algorithm SHA1 ...
$ prm --gpg --gpg_sign_algorithm SHA512 ...
```