### PR TITLE
gpg integration is improved

### DIFF
--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -208,7 +208,7 @@ module Debian
 
             if gpg.nil?
               sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" --no-tty --yes --output Release.gpg -b Release"
-            elsif !gpg_passphrase.nil?
+            elsif gpg_passphrase
               sign_cmd = "echo \'#{gpg_passphrase}\' | gpg --digest-algo \"#{sign_algorithm}\" --no-tty -u #{gpg} --passphrase-fd 0 --yes --output Release.gpg -b Release"
             else
               sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" -u #{gpg} --no-tty --yes --output Release.gpg -b Release"

--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -207,11 +207,11 @@ module Debian
             end
 
             if gpg.nil?
-              sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" --yes --output Release.gpg -b Release"
+              sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" --no-tty --yes --output Release.gpg -b Release"
             elsif !gpg_passphrase.nil?
-              sign_cmd = "echo \'#{gpg_passphrase}\' | gpg --digest-algo \"#{sign_algorithm}\" -u #{gpg} --passphrase-fd 0 --yes --output Release.gpg -b Release"
+              sign_cmd = "echo \'#{gpg_passphrase}\' | gpg --digest-algo \"#{sign_algorithm}\" --no-tty -u #{gpg} --passphrase-fd 0 --yes --output Release.gpg -b Release"
             else
-              sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" -u #{gpg} --yes --output Release.gpg -b Release"
+              sign_cmd = "gpg --digest-algo \"#{sign_algorithm}\" -u #{gpg} --no-tty --yes --output Release.gpg -b Release"
             end
             system sign_cmd
         end


### PR DESCRIPTION
We operate `PRM` via another controlling process (a web app) that does not have access to tty.  However, without access to `tty`, gpg fails, and the release is not signed - leading to all kinds of problems.  This was also experienced here, it seems:

https://github.com/dnbert/prm/issues/69

While adding the tty flag, we found that though `gpg_passphrase` is set to `false` by `Clamp`, the logic seems to be predicated on it being `nil`.

Result of a prm invocation without a passphrase:

```
sign_cmd = echo 'false' | gpg --digest-algo \"SHA256\" -u <KeyID> --passphrase-fd 0 --yes --output Release.gpg -b Release
```

An unprotected key doesn't seem to mind if you pass it the wrong password, so it's possible to eliminate the third branch entirely, but that seems sloppy.