### PR TITLE
Repo Date format is incorrect for Debian

### DIFF
--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -161,7 +161,7 @@ module Debian
 	# https://tools.ietf.org/html/rfc5322#section-3.3
 	# https://wiki.debian.org/RepositoryFormat#Date.2CValid-Until
 	ENV['TZ'] = 'UTC'
-        date = Time.now.utc
+        date = Time.now
 
         release_info = Hash.new()
         unreasonable_array = ["Packages", "Packages.gz", "Release"]

--- a/lib/prm/repo.rb
+++ b/lib/prm/repo.rb
@@ -155,6 +155,12 @@ module Debian
     end
 
     def generate_release(path,release,component,arch,label,origin)
+
+	# Debian enforces RFC5322 3.3, which suggests UTC to be denoted
+	# as +0000.
+	# https://tools.ietf.org/html/rfc5322#section-3.3
+	# https://wiki.debian.org/RepositoryFormat#Date.2CValid-Until
+	ENV['TZ'] = 'UTC'
         date = Time.now.utc
 
         release_info = Hash.new()


### PR DESCRIPTION
Perhaps there is a better way to do this, but I simply changed the timezone to 'UTC' and called time.now, instead of time.now.utc. This complies with:

https://wiki.debian.org/RepositoryFormat#Date.2CValid-Until
https://tools.ietf.org/html/rfc5322#section-3.3